### PR TITLE
session12 -不具合の修正

### DIFF
--- a/Example/Example/Data/WeatherError.swift
+++ b/Example/Example/Data/WeatherError.swift
@@ -12,4 +12,6 @@ enum WeatherError: Error {
     case jsonEncodeError
     case jsonDecodeError
     case unknownError
+    case yumemiUnknownError
+    case yumemiInvalidParameterError
 }

--- a/Example/Example/UI/Weather/WeatherViewController.swift
+++ b/Example/Example/UI/Weather/WeatherViewController.swift
@@ -63,7 +63,7 @@ class WeatherViewController: UIViewController {
             self.maxTempLabel.text = String(response.maxTemp)
             
         case .failure(let error):
-            var message: String  = ""
+            let message: String
             switch error {
             case .jsonEncodeError:
                 message = "Jsonエンコードに失敗しました。"

--- a/Example/Example/UI/Weather/WeatherViewController.swift
+++ b/Example/Example/UI/Weather/WeatherViewController.swift
@@ -63,14 +63,18 @@ class WeatherViewController: UIViewController {
             self.maxTempLabel.text = String(response.maxTemp)
             
         case .failure(let error):
-            let message: String
+            var message: String  = ""
             switch error {
             case .jsonEncodeError:
                 message = "Jsonエンコードに失敗しました。"
             case .jsonDecodeError:
                 message = "Jsonデコードに失敗しました。"
             case .unknownError:
+                message = "不明なエラーが発生しました。"
+            case .yumemiUnknownError:
                 message = "エラーが発生しました。"
+            case .yumemiInvalidParameterError:
+                message = "不正なパラメータです"
             }
             
             let alertController = UIAlertController(title: "Error", message: message, preferredStyle: .alert)

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -27,51 +27,50 @@ class WeatherViewControllerTests: XCTestCase {
     }
 
     func test_天気予報がsunnyだったらImageViewのImageにsunnyが設定されること_TintColorがredに設定されること() throws {
-        weatherModel.fetchWeatherImpl = { _ in
-            Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
-        }
+        weatherModel.response = Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         
-        weatherViewController.loadWeather()
-        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.red())
-        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.sunny())
+        weatherModel.fetchWeather(at: "", date: Date()) { result in
+            self.weatherViewController.handleWeather(result: result)
+            XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.red())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.sunny())
+        }
     }
     
     func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() throws {
-        weatherModel.fetchWeatherImpl = { _ in
-            Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
-        }
+        weatherModel.response = Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
         
-        weatherViewController.loadWeather()
-        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.gray())
-        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.cloudy())
+        weatherModel.fetchWeather(at: "", date: Date()) { result in
+            self.weatherViewController.handleWeather(result: result)
+            XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.gray())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.cloudy())
+        }
     }
     
     func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() throws {
-        weatherModel.fetchWeatherImpl = { _ in
-            Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
-        }
+        weatherModel.response = Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
         
-        weatherViewController.loadWeather()
-        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.blue())
-        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.rainy())
+        weatherModel.fetchWeather(at: "", date: Date()) { result in
+            self.weatherViewController.handleWeather(result: result)
+            XCTAssertEqual(self.weatherViewController.weatherImageView.tintColor, R.color.blue())
+            XCTAssertEqual(self.weatherViewController.weatherImageView.image, R.image.rainy())
+        }
     }
     
     func test_最高気温_最低気温がUILabelに設定されること() throws {
-        weatherModel.fetchWeatherImpl = { _ in
-            Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
-        }
+        weatherModel.response = Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
         
-        weatherViewController.loadWeather()
-        XCTAssertEqual(weatherViewController.minTempLabel.text, "-100")
-        XCTAssertEqual(weatherViewController.maxTempLabel.text, "100")
+        weatherModel.fetchWeather(at: "", date: Date()) { result in
+            self.weatherViewController.handleWeather(result: result)
+            XCTAssertEqual(self.weatherViewController.minTempLabel.text, "-100")
+            XCTAssertEqual(self.weatherViewController.maxTempLabel.text, "100")
+        }
     }
 }
 
 class WeatherModelMock: WeatherModel {
+    var response: Response!
     
-    var fetchWeatherImpl: ((Request) throws -> Response)!
-    
-    func fetchWeather(_ request: Request) throws -> Response {
-        return try fetchWeatherImpl(request)
+    func fetchWeather(at area: String, date: Date, completion: @escaping (Result<Response, WeatherError>) -> Void) {
+        completion(.success(response))
     }
 }

--- a/Example/ExampleTests/WeatherViewControllerTests.swift
+++ b/Example/ExampleTests/WeatherViewControllerTests.swift
@@ -12,14 +12,14 @@ import YumemiWeather
 
 class WeatherViewControllerTests: XCTestCase {
 
-    var weahterViewController: WeatherViewController!
-    var weahterModel: WeatherModelMock!
+    var weatherViewController: WeatherViewController!
+    var weatherModel: WeatherModelMock!
     
     override func setUpWithError() throws {
-        weahterModel = WeatherModelMock()
-        weahterViewController = R.storyboard.weather.instantiateInitialViewController()!
-        weahterViewController.weatherModel = weahterModel
-        _ = weahterViewController.view
+        weatherModel = WeatherModelMock()
+        weatherViewController = R.storyboard.weather.instantiateInitialViewController()!
+        weatherViewController.weatherModel = weatherModel
+        _ = weatherViewController.view
     }
 
     override func tearDownWithError() throws {
@@ -27,43 +27,43 @@ class WeatherViewControllerTests: XCTestCase {
     }
 
     func test_天気予報がsunnyだったらImageViewのImageにsunnyが設定されること_TintColorがredに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .sunny, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.red())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.sunny())
+        weatherViewController.loadWeather()
+        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.red())
+        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.sunny())
     }
     
     func test_天気予報がcloudyだったらImageViewのImageにcloudyが設定されること_TintColorがgrayに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .cloudy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.gray())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.cloudy())
+        weatherViewController.loadWeather()
+        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.gray())
+        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.cloudy())
     }
     
     func test_天気予報がrainyだったらImageViewのImageにrainyが設定されること_TintColorがblueに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 0, minTemp: 0, date: Date())
         }
         
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.weatherImageView.tintColor, R.color.blue())
-        XCTAssertEqual(weahterViewController.weatherImageView.image, R.image.rainy())
+        weatherViewController.loadWeather()
+        XCTAssertEqual(weatherViewController.weatherImageView.tintColor, R.color.blue())
+        XCTAssertEqual(weatherViewController.weatherImageView.image, R.image.rainy())
     }
     
     func test_最高気温_最低気温がUILabelに設定されること() throws {
-        weahterModel.fetchWeatherImpl = { _ in
+        weatherModel.fetchWeatherImpl = { _ in
             Response(weather: .rainy, maxTemp: 100, minTemp: -100, date: Date())
         }
         
-        weahterViewController.loadWeather()
-        XCTAssertEqual(weahterViewController.minTempLabel.text, "-100")
-        XCTAssertEqual(weahterViewController.maxTempLabel.text, "100")
+        weatherViewController.loadWeather()
+        XCTAssertEqual(weatherViewController.minTempLabel.text, "-100")
+        XCTAssertEqual(weatherViewController.maxTempLabel.text, "100")
     }
 }
 


### PR DESCRIPTION
# 変更内容
## タイポの修正
### どういう状態だったか
- WeatherViewControllerTests内の変数名が _weahterViewController_ と _weahterModel_ になっていた
### どう改善したか
- それぞれ _weahter_ となっていた部分をweatherに修正

## テストパスするように修正
### どういう状態だったか
- WeatherViewControllerTests内でコンパイルエラーが発生したため、テスト実行すらできなかった
### 何が原因だったか
- WeatherModelMockがWeatherModelプロトコルの関数を批准していなかった
- weahterViewController.loadWeather()ではloadWeatherの引数にsenderが必要だった
### どう改善したか
- WeatherModelプロトコルの関数を批准した
- それに伴ってfetchWeatherImpl変数ではなく、response変数をfetchWeatherのcompletion返すようにした
- loadWeatherで天気の情報を取得するのではなくfetchWeatherで取得するようにした

## 正しいエラーを返すように修正
### どういう状態だったか
- 天気の情報を取得する際にエラーが発生するとロード状態から進まなかった
### 何が原因だったか
- WeatheModelImplのfetchWeather()で正しくエラーを返せていなかった
- 発生するはずのエラーがWeatherErrorに記述されていなかった
### どう改善したか
- fetchWeather()でif分岐していたものをdo-catchでエラーを返せるようにした
- YumemiWeahterErrorに対応できるようにWeatherErrorに _yumemiUnknownError_ と _yumemiInvalidParameterError_ を追加した
- それに伴い、WeatherErrorにinitをextensionした
- 追加したエラーに対応できるようにWeatherViewControllerのhandleWeather()に処理を追加した